### PR TITLE
Tools update (SYN-9796, SYN-9797)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             python3 -m venv --copies venv
             . venv/bin/activate
             python3 -m pip install -U wheel pip
-            python3 -m pip install -U -r requirements.txt
+            python3 -m pip install -U -r requirements_dev.txt
 
       - save_cache:
           paths:
@@ -30,7 +30,8 @@ commands:
     description: "Run tests"
     steps:
 
-      - checkout
+      - checkout:
+          method: blobless
 
       - setup_venv_cached
 

--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,12 @@ for an Advanced Power-Up, the following steps should be done:
     python -m pip install -U -r requirements.txt
 
 2. Replace the ``3faafd06b11d05ed4f8a126236de63c3`` guid value in the repository with a random value. You can use
-   ``python -m synapse.tools.guid`` to generate a random guid for this purpose. This ensures that your Power-Up will
+   ``python -m synapse.tools.utils.guid`` to generate a random guid for this purpose. This ensures that your Power-Up will
    have a unique guid for its ``meta:source`` node. You can use the following commands to do that:
 
   ::
 
-    export NEW_GUID="$(python -m synapse.tools.guid)"
+    export NEW_GUID="$(python -m synapse.tools.utils.guid)"
     echo "Updating guid to $NEW_GUID" && find ./synmods/ -type f -exec sed -i "s/3faafd06b11d05ed4f8a126236de63c3/$NEW_GUID/gI" {} \;
     # add the changed files and commit them.
     git add -p

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -15,4 +15,4 @@ RUN ["/build/bootstrap.sh"]
 # Set the entrypoint for the container to the server
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.service.healthcheck -c cell:///vertex/storage/

--- a/docker/scripts/bootstrap.sh
+++ b/docker/scripts/bootstrap.sh
@@ -5,8 +5,7 @@ set -e
 
 if [ -d /build/package ]; then
     cd /build/package
-    python -m pip install --break-system-packages vtx-common
-    SYN_LOG_LEVEL=DEBUG python -m vtx_common.tools.buildpkg synmods/*/assets/*.yaml
+    SYN_LOG_LEVEL=DEBUG python -m synapse.tools.storm.pkg.doc synmods/*/assets/*.yaml
     python -m pip install --break-system-packages /build/package
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'synapse>=2.178.0,<3.0.0',
+    'synapse>=2.225.0,<3.0.0',
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@
 # These should not be the requirements used for deploying or installing
 # any python code associated with the service.
 #######################################################################
-synapse>=2.178.0,<3.0.0
-vtx-common>=0.1.26,<0.2.0
-build
+synapse>=2.225.0,<3.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+vtx-common>=0.1.26,<0.2.0
+build

--- a/synmods/examplepowerup/service.py
+++ b/synmods/examplepowerup/service.py
@@ -4,7 +4,7 @@ import collections.abc
 import synapse.lib.cell as s_cell
 import synapse.lib.stormsvc as s_stormsvc
 
-import synapse.tools.genpkg as s_genpkg
+import synapse.tools.storm.pkg.gen as s_genpkg
 
 import synmods.examplepowerup.assets as svc_assets
 import synmods.examplepowerup.version as svc_version


### PR DESCRIPTION
- CircleCI: Use blobless checkouts
- Remove vtx_common & its associated deps from docker builds.
- Update docker builds to use synapse.tools.storm.pkg.doc.
- Update service import to use synapse.tools.storm.pkg.gen.
- Update Dockerfile HEALTHCHECK.